### PR TITLE
Ruby: add Gemfile with test-unit dependency to make test runner UI work in RubyMine/IntelliJ

### DIFF
--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -1,0 +1,1 @@
+gem 'test-unit'

--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -1,0 +1,9 @@
+GEM
+  specs:
+    test-unit (2.5.5)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  test-unit


### PR DESCRIPTION
When running the tests for the Ruby version inside IntelliJ (same seems
to apply to RuybMine) the test runner UI didn't work: The failure

"test framework quit unexpectedly"

was shown. Following the advice from

http://www.jetbrains.com/ruby/webhelp/test-unit-special-notes.html

to add the test-unit gem to the project fixes this issue.
