### PR TITLE
Add rubygems.org as bundler source

### DIFF
--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -1,1 +1,3 @@
+source 'https://rubygems.org'
+
 gem 'test-unit'

--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -1,4 +1,5 @@
 GEM
+  remote: https://rubygems.org/
   specs:
     test-unit (2.5.5)
 
@@ -7,3 +8,6 @@ PLATFORMS
 
 DEPENDENCIES
   test-unit
+
+BUNDLED WITH
+   1.10.6


### PR DESCRIPTION
Bundler will complain unless the gem is already installed on your machine

```bash
$ bundle
Your Gemfile has no gem server sources. If you need gems that are not already on your machine, add a line like this to your Gemfile:
source 'https://rubygems.org'
Could not find test-unit-2.5.5 in any of the sources
```