### PR TITLE
Makes scala code testable with sbt and adds minimal readme.

### DIFF
--- a/scala/README.md
+++ b/scala/README.md
@@ -1,0 +1,5 @@
+## Tennis in scala
+
+To run all tests continuously type `sbt "~test"` in the console in the `scala` directory.
+
+

--- a/scala/build.sbt
+++ b/scala/build.sbt
@@ -2,9 +2,10 @@ name := "Tennis"
 
 version := "1.0"
 
-scalaVersion := "2.10.2"
+scalaVersion := "2.12.2"
 
 libraryDependencies ++= Seq(
-  "org.scalatest" % "scalatest_2.10" % "2.0",
-  "junit" % "junit" % "4.8.1"
+  "org.scalatest" %% "scalatest" % "3.0.1",
+  "junit" % "junit" % "4.12",
+  "com.novocode" % "junit-interface" % "0.11" % "test->default"
 )


### PR DESCRIPTION
Without `"com.novocode" % "junit-interface" % "0.11" % "test->default"`
`sbt test` does not run the jUnit tests in the scala repo.

I suggest adding `junit-interface`, as `sbt test` is the standard way to run tests with scala :)

Also I would be open to redo the tests a little bit, to be more scala like, if this is wanted ;)