### PR TITLE
Swift version

### DIFF
--- a/swift/.gitignore
+++ b/swift/.gitignore
@@ -1,0 +1,31 @@
+# Ios
+DerivedData
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+*.xccheckout
+*.moved-aside
+*.xcuserstate
+*.xcscmblueprint
+*.hmap
+*.ipa
+*.app.dSYM.zip
+*.xcarchive
+*.xcarchive.zip
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns

--- a/swift/Tennis.xcodeproj/project.pbxproj
+++ b/swift/Tennis.xcodeproj/project.pbxproj
@@ -1,0 +1,302 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 48;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		52EF22791F892FF600CAD019 /* TennisTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52EF22781F892FF600CAD019 /* TennisTests.swift */; };
+		52EF22801F89307F00CAD019 /* TennisGame.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52EF227F1F89307F00CAD019 /* TennisGame.swift */; };
+		52EF22821F89316100CAD019 /* TennisGame1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52EF22811F89316100CAD019 /* TennisGame1.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		52EF22751F892FF600CAD019 /* TennisTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TennisTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		52EF22781F892FF600CAD019 /* TennisTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TennisTests.swift; sourceTree = "<group>"; };
+		52EF227A1F892FF600CAD019 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		52EF227F1F89307F00CAD019 /* TennisGame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TennisGame.swift; sourceTree = "<group>"; };
+		52EF22811F89316100CAD019 /* TennisGame1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TennisGame1.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		52EF22721F892FF600CAD019 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		52EF226A1F892FC100CAD019 = {
+			isa = PBXGroup;
+			children = (
+				52EF227E1F89301400CAD019 /* Tennis */,
+				52EF22771F892FF600CAD019 /* TennisTests */,
+				52EF22761F892FF600CAD019 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		52EF22761F892FF600CAD019 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				52EF22751F892FF600CAD019 /* TennisTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		52EF22771F892FF600CAD019 /* TennisTests */ = {
+			isa = PBXGroup;
+			children = (
+				52EF22781F892FF600CAD019 /* TennisTests.swift */,
+				52EF227A1F892FF600CAD019 /* Info.plist */,
+			);
+			path = TennisTests;
+			sourceTree = "<group>";
+		};
+		52EF227E1F89301400CAD019 /* Tennis */ = {
+			isa = PBXGroup;
+			children = (
+				52EF22811F89316100CAD019 /* TennisGame1.swift */,
+				52EF227F1F89307F00CAD019 /* TennisGame.swift */,
+			);
+			path = Tennis;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		52EF22741F892FF600CAD019 /* TennisTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 52EF227B1F892FF600CAD019 /* Build configuration list for PBXNativeTarget "TennisTests" */;
+			buildPhases = (
+				52EF22711F892FF600CAD019 /* Sources */,
+				52EF22721F892FF600CAD019 /* Frameworks */,
+				52EF22731F892FF600CAD019 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = TennisTests;
+			productName = TennisTests;
+			productReference = 52EF22751F892FF600CAD019 /* TennisTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		52EF226B1F892FC100CAD019 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 0900;
+				LastUpgradeCheck = 0900;
+				TargetAttributes = {
+					52EF22741F892FF600CAD019 = {
+						CreatedOnToolsVersion = 9.0;
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = 52EF226E1F892FC100CAD019 /* Build configuration list for PBXProject "Tennis" */;
+			compatibilityVersion = "Xcode 8.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 52EF226A1F892FC100CAD019;
+			productRefGroup = 52EF22761F892FF600CAD019 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				52EF22741F892FF600CAD019 /* TennisTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		52EF22731F892FF600CAD019 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		52EF22711F892FF600CAD019 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				52EF22821F89316100CAD019 /* TennisGame1.swift in Sources */,
+				52EF22801F89307F00CAD019 /* TennisGame.swift in Sources */,
+				52EF22791F892FF600CAD019 /* TennisTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		52EF226F1F892FC100CAD019 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+			};
+			name = Debug;
+		};
+		52EF22701F892FC100CAD019 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+			};
+			name = Release;
+		};
+		52EF227C1F892FF600CAD019 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = TennisTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ivanrublev.TennisTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		52EF227D1F892FF600CAD019 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = TennisTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ivanrublev.TennisTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		52EF226E1F892FC100CAD019 /* Build configuration list for PBXProject "Tennis" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				52EF226F1F892FC100CAD019 /* Debug */,
+				52EF22701F892FC100CAD019 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		52EF227B1F892FF600CAD019 /* Build configuration list for PBXNativeTarget "TennisTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				52EF227C1F892FF600CAD019 /* Debug */,
+				52EF227D1F892FF600CAD019 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 52EF226B1F892FC100CAD019 /* Project object */;
+}

--- a/swift/Tennis.xcodeproj/project.pbxproj
+++ b/swift/Tennis.xcodeproj/project.pbxproj
@@ -7,12 +7,14 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		520065DE1F8972C5006EDBDF /* TennisGame2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 520065DD1F8972C5006EDBDF /* TennisGame2.swift */; };
 		52EF22791F892FF600CAD019 /* TennisTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52EF22781F892FF600CAD019 /* TennisTests.swift */; };
 		52EF22801F89307F00CAD019 /* TennisGame.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52EF227F1F89307F00CAD019 /* TennisGame.swift */; };
 		52EF22821F89316100CAD019 /* TennisGame1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52EF22811F89316100CAD019 /* TennisGame1.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		520065DD1F8972C5006EDBDF /* TennisGame2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TennisGame2.swift; sourceTree = "<group>"; };
 		52EF22751F892FF600CAD019 /* TennisTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TennisTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		52EF22781F892FF600CAD019 /* TennisTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TennisTests.swift; sourceTree = "<group>"; };
 		52EF227A1F892FF600CAD019 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -61,6 +63,7 @@
 			isa = PBXGroup;
 			children = (
 				52EF22811F89316100CAD019 /* TennisGame1.swift */,
+				520065DD1F8972C5006EDBDF /* TennisGame2.swift */,
 				52EF227F1F89307F00CAD019 /* TennisGame.swift */,
 			);
 			path = Tennis;
@@ -134,6 +137,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				52EF22821F89316100CAD019 /* TennisGame1.swift in Sources */,
+				520065DE1F8972C5006EDBDF /* TennisGame2.swift in Sources */,
 				52EF22801F89307F00CAD019 /* TennisGame.swift in Sources */,
 				52EF22791F892FF600CAD019 /* TennisTests.swift in Sources */,
 			);

--- a/swift/Tennis.xcodeproj/project.pbxproj
+++ b/swift/Tennis.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		520065DE1F8972C5006EDBDF /* TennisGame2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 520065DD1F8972C5006EDBDF /* TennisGame2.swift */; };
+		520065E01F897A01006EDBDF /* TennisGame3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 520065DF1F897A01006EDBDF /* TennisGame3.swift */; };
 		52EF22791F892FF600CAD019 /* TennisTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52EF22781F892FF600CAD019 /* TennisTests.swift */; };
 		52EF22801F89307F00CAD019 /* TennisGame.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52EF227F1F89307F00CAD019 /* TennisGame.swift */; };
 		52EF22821F89316100CAD019 /* TennisGame1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52EF22811F89316100CAD019 /* TennisGame1.swift */; };
@@ -15,6 +16,7 @@
 
 /* Begin PBXFileReference section */
 		520065DD1F8972C5006EDBDF /* TennisGame2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TennisGame2.swift; sourceTree = "<group>"; };
+		520065DF1F897A01006EDBDF /* TennisGame3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TennisGame3.swift; sourceTree = "<group>"; };
 		52EF22751F892FF600CAD019 /* TennisTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TennisTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		52EF22781F892FF600CAD019 /* TennisTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TennisTests.swift; sourceTree = "<group>"; };
 		52EF227A1F892FF600CAD019 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -64,6 +66,7 @@
 			children = (
 				52EF22811F89316100CAD019 /* TennisGame1.swift */,
 				520065DD1F8972C5006EDBDF /* TennisGame2.swift */,
+				520065DF1F897A01006EDBDF /* TennisGame3.swift */,
 				52EF227F1F89307F00CAD019 /* TennisGame.swift */,
 			);
 			path = Tennis;
@@ -136,6 +139,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				520065E01F897A01006EDBDF /* TennisGame3.swift in Sources */,
 				52EF22821F89316100CAD019 /* TennisGame1.swift in Sources */,
 				520065DE1F8972C5006EDBDF /* TennisGame2.swift in Sources */,
 				52EF22801F89307F00CAD019 /* TennisGame.swift in Sources */,

--- a/swift/Tennis.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/swift/Tennis.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:Tennis.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/swift/Tennis.xcodeproj/xcshareddata/xcschemes/TennisTests.xcscheme
+++ b/swift/Tennis.xcodeproj/xcshareddata/xcschemes/TennisTests.xcscheme
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0900"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "52EF22741F892FF600CAD019"
+               BuildableName = "TennisTests.xctest"
+               BlueprintName = "TennisTests"
+               ReferencedContainer = "container:Tennis.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/swift/Tennis/TennisGame.swift
+++ b/swift/Tennis/TennisGame.swift
@@ -2,7 +2,7 @@
 //  TennisGame.swift
 //  TennisTests
 //
-//  Created by Test on 07/10/2017.
+//  Created by Ivan Rublev on 07/10/2017.
 //
 
 import Foundation

--- a/swift/Tennis/TennisGame.swift
+++ b/swift/Tennis/TennisGame.swift
@@ -1,0 +1,14 @@
+//
+//  TennisGame.swift
+//  TennisTests
+//
+//  Created by Test on 07/10/2017.
+//
+
+import Foundation
+
+protocol TennisGame {
+    init(player1: String, player2: String)
+    func wonPoint(_ playerName: String)
+    var score: String? { get }
+}

--- a/swift/Tennis/TennisGame.swift
+++ b/swift/Tennis/TennisGame.swift
@@ -1,10 +1,3 @@
-//
-//  TennisGame.swift
-//  TennisTests
-//
-//  Created by Ivan Rublev on 07/10/2017.
-//
-
 import Foundation
 
 protocol TennisGame {

--- a/swift/Tennis/TennisGame1.swift
+++ b/swift/Tennis/TennisGame1.swift
@@ -21,7 +21,7 @@ class TennisGame1: TennisGame {
     }
 
     func wonPoint(_ playerName: String) {
-        if playerName == player1 {
+        if playerName == "player1" {
             score1 += 1
         } else {
             score2 += 1

--- a/swift/Tennis/TennisGame1.swift
+++ b/swift/Tennis/TennisGame1.swift
@@ -1,10 +1,3 @@
-//
-//  TennisGame1.swift
-//  TennisTests
-//
-//  Created by Ivan Rublev on 07/10/2017.
-//
-
 import Foundation
 
 class TennisGame1: TennisGame {

--- a/swift/Tennis/TennisGame1.swift
+++ b/swift/Tennis/TennisGame1.swift
@@ -2,7 +2,7 @@
 //  TennisGame1.swift
 //  TennisTests
 //
-//  Created by Test on 07/10/2017.
+//  Created by Ivan Rublev on 07/10/2017.
 //
 
 import Foundation

--- a/swift/Tennis/TennisGame1.swift
+++ b/swift/Tennis/TennisGame1.swift
@@ -1,0 +1,90 @@
+//
+//  TennisGame1.swift
+//  TennisTests
+//
+//  Created by Test on 07/10/2017.
+//
+
+import Foundation
+
+class TennisGame1: TennisGame {
+    private let player1: String
+    private let player2: String
+    private var score1: Int
+    private var score2: Int
+    
+    required init(player1: String, player2: String) {
+        self.player1 = player1
+        self.player2 = player2
+        self.score1 = 0
+        self.score2 = 0
+    }
+
+    func wonPoint(_ playerName: String) {
+        if playerName == player1 {
+            score1 += 1
+        } else {
+            score2 += 1
+        }
+    }
+    
+    var score: String? {
+        var score = ""
+        var tempScore = 0
+        if score1 == score2
+        {
+            switch score1
+            {
+            case 0:
+                score = "Love-All"
+
+            case 1:
+                score = "Fifteen-All"
+
+            case 2:
+                score = "Thirty-All"
+
+            default:
+                score = "Deuce"
+                
+            }
+        }
+        else if score1>=4 || score2>=4
+        {
+            let minusResult = score1-score2
+            if minusResult==1 { score = "Advantage player1" }
+            else if minusResult  == -1 { score = "Advantage player2" }
+            else if minusResult>=2 { score = "Win for player1" }
+            else { score = "Win for player2" }
+        }
+        else
+        {
+            for i in 1..<3
+            {
+                if i==1 { tempScore = score1 }
+                else { score = "\(score)-"; tempScore = score2 }
+                switch tempScore
+                {
+                case 0:
+                    score = "\(score)Love"
+
+                case 1:
+                    score = "\(score)Fifteen"
+
+                case 2:
+                    score = "\(score)Thirty"
+
+                case 3:
+                    score = "\(score)Forty"
+
+                default:
+                    break
+
+                }
+            }
+        }
+        return score
+    }
+    
+    
+}

--- a/swift/Tennis/TennisGame2.swift
+++ b/swift/Tennis/TennisGame2.swift
@@ -1,0 +1,140 @@
+//
+//  TennisGame2.swift
+//  TennisTests
+//
+//  Created by Test on 07/10/2017.
+//
+
+import Foundation
+
+class TennisGame2: TennisGame {
+    private let player1Name: String
+    private let player2Name: String
+    private var P1point: Int = 0
+    private var P1res: String = ""
+    private var P2point: Int = 0
+    private var P2res: String = ""
+
+    required init(player1: String, player2: String) {
+        player1Name = player1
+        player2Name = player2
+    }
+
+    var score: String? {
+        var score = ""
+        if P1point == P2point && P1point < 3
+        {
+            if P1point==0
+            { score = "Love" }
+            if P1point==1
+            { score = "Fifteen" }
+            if P1point==2
+            { score = "Thirty" }
+            score = "\(score)-All"
+        }
+        if P1point==P2point && P1point>2
+        { score = "Deuce" }
+
+        if P1point > 0 && P2point==0
+        {
+            if (P1point==1)
+            { P1res = "Fifteen" }
+            if (P1point==2)
+            { P1res = "Thirty" }
+            if (P1point==3)
+            { P1res = "Forty" }
+            
+            P2res = "Love"
+            score = "\(P1res)-\(P2res)"
+        }
+        if P2point > 0 && P1point==0
+        {
+            if (P2point==1)
+            { P2res = "Fifteen" }
+            if (P2point==2)
+            { P2res = "Thirty" }
+            if (P2point==3)
+            { P2res = "Forty" }
+            
+            P1res = "Love"
+            score = "\(P1res)-\(P2res)"
+        }
+        
+        if (P1point>P2point && P1point < 4)
+        {
+            if (P1point==2)
+            { P1res="Thirty" }
+            if (P1point==3)
+            { P1res="Forty" }
+            if (P2point==1)
+            { P2res="Fifteen" }
+            if (P2point==2)
+            { P2res="Thirty" }
+            score = "\(P1res)-\(P2res)"
+        }
+        if P2point>P1point && P2point < 4
+        {
+            if (P2point==2)
+            { P2res="Thirty" }
+            if (P2point==3)
+            { P2res="Forty" }
+            if (P1point==1)
+            { P1res="Fifteen" }
+            if (P1point==2)
+            { P1res="Thirty" }
+            score = "\(P1res)-\(P2res)"
+        }
+        
+        if P1point > P2point && P2point >= 3
+        {
+            score = "Advantage player1"
+        }
+        
+        if P2point > P1point && P1point >= 3
+        {
+            score = "Advantage player2"
+        }
+        
+        if P1point>=4 && P2point>=0 && (P1point-P2point)>=2
+        {
+            score = "Win for player1"
+        }
+        if P2point>=4 && P1point>=0 && (P2point-P1point)>=2
+        {
+            score = "Win for player2"
+        }
+        return score
+    }
+    
+   private func setP1Score(number: Int) {
+        
+        for _ in 0..<number {
+            P1Score()
+        }
+        
+    }
+
+    private func setP2Score(number: Int) {
+        
+        for _ in 0..<number {
+            P2Score()
+        }
+        
+    }
+    
+    private func P1Score() {
+        P1point+=1
+    }
+    
+    private func P2Score() {
+        P2point+=1
+    }
+    
+    func wonPoint(_ playerName: String) {
+        if playerName == "player1" {
+            P1Score()
+        } else {
+            P2Score()
+        }
+    }
+}

--- a/swift/Tennis/TennisGame2.swift
+++ b/swift/Tennis/TennisGame2.swift
@@ -1,10 +1,3 @@
-//
-//  TennisGame2.swift
-//  TennisTests
-//
-//  Created by Ivan Rublev on 07/10/2017.
-//
-
 import Foundation
 
 class TennisGame2: TennisGame {

--- a/swift/Tennis/TennisGame2.swift
+++ b/swift/Tennis/TennisGame2.swift
@@ -2,7 +2,7 @@
 //  TennisGame2.swift
 //  TennisTests
 //
-//  Created by Test on 07/10/2017.
+//  Created by Ivan Rublev on 07/10/2017.
 //
 
 import Foundation

--- a/swift/Tennis/TennisGame3.swift
+++ b/swift/Tennis/TennisGame3.swift
@@ -1,10 +1,3 @@
-//
-//  TennisGame3.swift
-//  TennisTests
-//
-//  Created by Ivan Rublev on 08/10/2017.
-//
-
 import Foundation
 
 class TennisGame3: TennisGame {

--- a/swift/Tennis/TennisGame3.swift
+++ b/swift/Tennis/TennisGame3.swift
@@ -2,7 +2,7 @@
 //  TennisGame3.swift
 //  TennisTests
 //
-//  Created by Test on 08/10/2017.
+//  Created by Ivan Rublev on 08/10/2017.
 //
 
 import Foundation

--- a/swift/Tennis/TennisGame3.swift
+++ b/swift/Tennis/TennisGame3.swift
@@ -1,0 +1,46 @@
+//
+//  TennisGame3.swift
+//  TennisTests
+//
+//  Created by Test on 08/10/2017.
+//
+
+import Foundation
+
+class TennisGame3: TennisGame {
+    private var p1: Int
+    private var p2: Int
+    private var p1N: String
+    private var p2N: String
+    
+    required init(player1: String, player2: String) {
+        p1N = player1
+        p2N = player2
+        p1 = 0
+        p2 = 0
+    }
+    
+    var score: String? {
+        var s: String
+        if (p1 < 4 && p2 < 4) && (p1 + p2 < 6) {
+            let p = ["Love", "Fifteen", "Thirty", "Forty"]
+            s = p[p1];
+            return (p1 == p2) ? "\(s)-All" : "\(s)-\(p[p2])"
+        } else {
+            if (p1 == p2)
+            { return "Deuce" }
+            s = p1 > p2 ? p1N : p2N;
+            return ((p1-p2)*(p1-p2) == 1) ? "Advantage \(s)" : "Win for \(s)"
+        }
+    }
+    
+    func wonPoint(_ playerName: String) {
+        if playerName == "player1" {
+            p1 += 1
+        } else {
+            p2 += 1
+        }
+    }
+
+    
+}

--- a/swift/TennisTests/Info.plist
+++ b/swift/TennisTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/swift/TennisTests/TennisTests.swift
+++ b/swift/TennisTests/TennisTests.swift
@@ -1,0 +1,105 @@
+//
+//  TennisTests.swift
+//  TennisTests
+//
+//  Created by Test on 07/10/2017.
+//
+
+import XCTest
+
+let parameters = [
+    (0, 0, "Love-All"),
+    (1, 1, "Fifteen-All"),
+    (2, 2, "Thirty-All"),
+    (3, 3, "Deuce"),
+    (4, 4, "Deuce"),
+    
+    (1, 0, "Fifteen-Love"),
+    (0, 1, "Love-Fifteen"),
+    (2, 0, "Thirty-Love"),
+    (0, 2, "Love-Thirty"),
+    (3, 0, "Forty-Love"),
+    (0, 3, "Love-Forty"),
+    (4, 0, "Win for player1"),
+    (0, 4, "Win for player2"),
+    
+    (2, 1, "Thirty-Fifteen"),
+    (1, 2, "Fifteen-Thirty"),
+    (3, 1, "Forty-Fifteen"),
+    (1, 3, "Fifteen-Forty"),
+    (4, 1, "Win for player1"),
+    (1, 4, "Win for player2"),
+    
+    (3, 2, "Forty-Thirty"),
+    (2, 3, "Thirty-Forty"),
+    (4, 2, "Win for player1"),
+    (2, 4, "Win for player2"),
+    
+    (4, 3, "Advantage player1"),
+    (3, 4, "Advantage player2"),
+    (5, 4, "Advantage player1"),
+    (4, 5, "Advantage player2"),
+    (15, 14, "Advantage player1"),
+    (14, 15, "Advantage player2"),
+    
+    (6, 4, "Win for player1"),
+    (4, 6, "Win for player2"),
+    (16, 14, "Win for player1"),
+    (14, 16, "Win for player2")
+]
+
+class TennisTests: XCTestCase {
+    var player1Score: Int!
+    var player2Score: Int!
+    var expectedScore: String!
+}
+
+// MARK: Suite
+extension TennisTests {
+    override open class var defaultTestSuite: XCTestSuite {
+        let testSuite = XCTestSuite(name: NSStringFromClass(self))
+        
+        for scores in parameters {
+            addTest(forEachInvocationWith: scores, to: testSuite)
+        }
+        
+        return testSuite
+    }
+    
+    class func addTest(forEachInvocationWith scores: (Int, Int, String), to testSuite: XCTestSuite) {
+        for testInvocation in testInvocations {
+            let test = TennisTests(invocation: testInvocation)
+            test.player1Score = scores.0
+            test.player2Score = scores.1
+            test.expectedScore = scores.2
+            testSuite.addTest(test)
+        }
+    }
+}
+
+// MARK: Invocations
+extension TennisTests {
+    func testAllScoresTennisGame1() {
+        let game = instantiateGame(class: TennisGame1.self)
+        checkAllScores(for: game)
+    }
+
+    func instantiateGame(class aClass: TennisGame.Type) -> TennisGame {
+        let instance = aClass.init(player1: "player1", player2: "player2")
+        return instance
+    }
+    
+    func checkAllScores(for game: TennisGame) {
+        print("\(player1Score!), \(player2Score!), \(expectedScore!)")
+        let highestScore = max(player1Score, player2Score);
+        for i in 0..<highestScore {
+            if i < player1Score {
+                game.wonPoint("player1")
+            }
+            if i < player2Score {
+                game.wonPoint("player2")
+            }
+        }
+        XCTAssertEqual(game.score, expectedScore)
+    }
+}

--- a/swift/TennisTests/TennisTests.swift
+++ b/swift/TennisTests/TennisTests.swift
@@ -2,7 +2,7 @@
 //  TennisTests.swift
 //  TennisTests
 //
-//  Created by Test on 07/10/2017.
+//  Created by Ivan Rublev on 07/10/2017.
 //
 
 import XCTest

--- a/swift/TennisTests/TennisTests.swift
+++ b/swift/TennisTests/TennisTests.swift
@@ -87,6 +87,10 @@ extension TennisTests {
         instantiateAndCheckGame(class: TennisGame2.self)
     }
 
+    func testAllScoresTennisGame3() {
+        instantiateAndCheckGame(class: TennisGame3.self)
+    }
+
     private func instantiateAndCheckGame(class aClass: TennisGame.Type) {
         let game = instantiateGame(class: aClass)
         checkAllScores(for: game)

--- a/swift/TennisTests/TennisTests.swift
+++ b/swift/TennisTests/TennisTests.swift
@@ -1,10 +1,3 @@
-//
-//  TennisTests.swift
-//  TennisTests
-//
-//  Created by Ivan Rublev on 07/10/2017.
-//
-
 import XCTest
 
 let parameters = [

--- a/swift/TennisTests/TennisTests.swift
+++ b/swift/TennisTests/TennisTests.swift
@@ -66,7 +66,7 @@ extension TennisTests {
         return testSuite
     }
     
-    class func addTest(forEachInvocationWith scores: (Int, Int, String), to testSuite: XCTestSuite) {
+    private class func addTest(forEachInvocationWith scores: (Int, Int, String), to testSuite: XCTestSuite) {
         for testInvocation in testInvocations {
             let test = TennisTests(invocation: testInvocation)
             test.player1Score = scores.0
@@ -80,16 +80,24 @@ extension TennisTests {
 // MARK: Invocations
 extension TennisTests {
     func testAllScoresTennisGame1() {
-        let game = instantiateGame(class: TennisGame1.self)
-        checkAllScores(for: game)
+        instantiateAndCheckGame(class: TennisGame1.self)
+    }
+    
+    func testAllScoresTennisGame2() {
+        instantiateAndCheckGame(class: TennisGame2.self)
     }
 
-    func instantiateGame(class aClass: TennisGame.Type) -> TennisGame {
+    private func instantiateAndCheckGame(class aClass: TennisGame.Type) {
+        let game = instantiateGame(class: aClass)
+        checkAllScores(for: game)
+    }
+    
+    private func instantiateGame(class aClass: TennisGame.Type) -> TennisGame {
         let instance = aClass.init(player1: "player1", player2: "player2")
         return instance
     }
     
-    func checkAllScores(for game: TennisGame) {
+    private func checkAllScores(for game: TennisGame) {
         print("\(player1Score!), \(player2Score!), \(expectedScore!)")
         let highestScore = max(player1Score, player2Score);
         for i in 0..<highestScore {


### PR DESCRIPTION
I've ported the Objective-C code to the Swift 4.0. It's runnable via Xcode 9. 
* Some code duplication is removed from the tests class.
* All `TennisGameN` classes adopt common `TennisGame` protocol instead of inheritance from the superclass as was in Objective-C version. If the superclass is important for kata, please let me know.