### PR TITLE
feat: Allow to build the CPP flavor using CMake

### DIFF
--- a/cpp/.gitignore
+++ b/cpp/.gitignore
@@ -1,1 +1,3 @@
 build
+.*
+cmake-build-debug

--- a/cpp/.gitignore
+++ b/cpp/.gitignore
@@ -1,2 +1,1 @@
-.*
-cmake-build-debug
+build

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,0 +1,9 @@
+project(Tennis-Refactoring)
+
+add_definitions(-DUSE_CMAKE)
+include_directories(${CMAKE_SOURCE_DIR})
+
+add_executable(tennis1_tests tennis1.cc all_tests.cpp all_tests.hpp test_suite.tests.cpp)
+add_executable(tennis2_tests tennis2.cc all_tests.cpp all_tests.hpp test_suite.tests.cpp)
+add_executable(tennis3_tests tennis3.cc all_tests.cpp all_tests.hpp test_suite.tests.cpp)
+

--- a/cpp/Readme.md
+++ b/cpp/Readme.md
@@ -1,0 +1,15 @@
+# Tennis-Refactoring-Kata C++
+
+## Using CMake, under Windows
+
+Sample setup (in a Windows console, using Git), and considering you are already located in this folder:
+```
+mkdir build
+cd build
+cmake .. -G "Visual Studio 14 2015 Win64"
+Tennis-Refactoring.sln
+```
+
+Visual Studio should start with the projects in it.
+You will have three different project, each one for a specific version of initial source code (1, 2 and 3).
+Tests are already complete, code is ready to refactor!

--- a/cpp/all_tests.cpp
+++ b/cpp/all_tests.cpp
@@ -1,7 +1,21 @@
 #include "all_tests.hpp"
 
-/* change this to the version of tennis you want to work on */
+
+
+#ifndef USE_CMAKE
+/*
+*
+* change this to the version of tennis you want to work on 
+*
+* NOTE: If you are using CMake rather than makefile, you
+*       don't have to touch this.
+* 
+*/
 #include "tennis1.cc"
+#else
+#include <string>
+const std::string tennis_score(int p1Score, int p2Score);
+#endif
 
 #include <cassert>
 


### PR DESCRIPTION
This PR contributes a CMake configuration file and a little hack which allow to use the CPP flavor of the Kata using CMake rather than "raw" cmake.