### PR TITLE
Uses current standard testing framework

### DIFF
--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'test-unit'
+gem 'minitest'

--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -1,13 +1,13 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    test-unit (2.5.5)
+    minitest (5.12.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  test-unit
+  minitest
 
 BUNDLED WITH
-   1.10.6
+   1.17.2

--- a/ruby/tennis_test.rb
+++ b/ruby/tennis_test.rb
@@ -1,6 +1,6 @@
-require File.join(File.dirname(__FILE__), 'tennis')
-#require_relative("tennis")
-require 'test/unit'
+require 'minitest'
+require 'minitest/autorun'
+require_relative "tennis"
 
 TEST_CASES = [
    [0, 0, "Love-All", 'player1', 'player2'],
@@ -8,7 +8,7 @@ TEST_CASES = [
    [2, 2, "Thirty-All", 'player1', 'player2'],
    [3, 3, "Deuce", 'player1', 'player2'],
    [4, 4, "Deuce", 'player1', 'player2'],
-   
+
    [1, 0, "Fifteen-Love", 'player1', 'player2'],
    [0, 1, "Love-Fifteen", 'player1', 'player2'],
    [2, 0, "Thirty-Love", 'player1', 'player2'],
@@ -17,38 +17,38 @@ TEST_CASES = [
    [0, 3, "Love-Forty", 'player1', 'player2'],
    [4, 0, "Win for player1", 'player1', 'player2'],
    [0, 4, "Win for player2", 'player1', 'player2'],
-   
+
    [2, 1, "Thirty-Fifteen", 'player1', 'player2'],
    [1, 2, "Fifteen-Thirty", 'player1', 'player2'],
    [3, 1, "Forty-Fifteen", 'player1', 'player2'],
    [1, 3, "Fifteen-Forty", 'player1', 'player2'],
    [4, 1, "Win for player1", 'player1', 'player2'],
    [1, 4, "Win for player2", 'player1', 'player2'],
-   
+
    [3, 2, "Forty-Thirty", 'player1', 'player2'],
    [2, 3, "Thirty-Forty", 'player1', 'player2'],
    [4, 2, "Win for player1", 'player1', 'player2'],
    [2, 4, "Win for player2", 'player1', 'player2'],
-   
+
    [4, 3, "Advantage player1", 'player1', 'player2'],
    [3, 4, "Advantage player2", 'player1', 'player2'],
    [5, 4, "Advantage player1", 'player1', 'player2'],
    [4, 5, "Advantage player2", 'player1', 'player2'],
    [15, 14, "Advantage player1", 'player1', 'player2'],
    [14, 15, "Advantage player2", 'player1', 'player2'],
-   
-   [6, 4, 'Win for player1', 'player1', 'player2'], 
-   [4, 6, 'Win for player2', 'player1', 'player2'], 
-   [16, 14, 'Win for player1', 'player1', 'player2'], 
-   [14, 16, 'Win for player2', 'player1', 'player2'], 
 
    [6, 4, 'Win for player1', 'player1', 'player2'],
-   [4, 6, 'Win for player2', 'player1', 'player2'], 
+   [4, 6, 'Win for player2', 'player1', 'player2'],
+   [16, 14, 'Win for player1', 'player1', 'player2'],
+   [14, 16, 'Win for player2', 'player1', 'player2'],
+
+   [6, 4, 'Win for player1', 'player1', 'player2'],
+   [4, 6, 'Win for player2', 'player1', 'player2'],
    [6, 5, 'Advantage player1', 'player1', 'player2'],
-   [5, 6, 'Advantage player2', 'player1', 'player2'] 
+   [5, 6, 'Advantage player2', 'player1', 'player2']
 ]
 
-class TestTennis < Test::Unit::TestCase
+class TestTennis < Minitest::Test
   def play_game(tennisGameClass, p1Points, p2Points, p1Name, p2Name)
     game = tennisGameClass.new(p1Name, p2Name)
     (0..[p1Points, p2Points].max).each do |i|
@@ -69,6 +69,7 @@ class TestTennis < Test::Unit::TestCase
       assert_equal(score, game.score())
     end
   end
+
   def test_Score_Game2
     TEST_CASES.each do |testcase|
       (p1Points, p2Points, score, p1Name, p2Name) = testcase
@@ -76,6 +77,7 @@ class TestTennis < Test::Unit::TestCase
       assert_equal(score, game.score())
     end
   end
+
   def test_Score_Game3
     TEST_CASES.each do |testcase|
       (p1Points, p2Points, score, p1Name, p2Name) = testcase


### PR DESCRIPTION
Hi Emily.

Thanks for creating this kata. This change is just for newer Ruby developers and test-unit is not used in newer projects anymore.

Current standard testing frameworks are Rspec and Minitest.