### PR TITLE
Remove references and broken links to cyber-dojo

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,3 @@ You need only report the score for the current game. Sets and Matches are out of
 * What would you say to your colleague if they had written this code?
 * What would you say to your boss about the value of this refactoring work? Was there more reason to do it over and above the extra billable hour or so?
 
-# Get going quickly with Cyber-dojo
-
-As an alternative to downloading the code, click one of the links below to create a new cyber-dojo to work in, then press "enter" to get going coding.
-
-- [Python](http://cyber-dojo.org/forker/fork/435E5C1C88?avatar=moose&tag=5)
-- [Ruby](http://cyber-dojo.org/forker/fork/3367E4B0E9?avatar=raccoon&tag=4)
-- [Java](http://cyber-dojo.org/forker/fork/4D363A34A7?avatar=vulture&tag=3)
-- [C++](http://cyber-dojo.org/forker/fork/A06DCDA217?avatar=wolf&tag=5)
-- [C#](http://cyber-dojo.org/forker/fork/672E047F5D?avatar=buffalo&tag=8)


### PR DESCRIPTION
The routes to access/fork stored sessions at cyber-dojo have changed, without an obvious way to fix past links. 
@emilybache made a similar commit in response to open issue on Racing-Car-Kata, removing the reference and the links to cyber-dojo for the time being. 
That commit: https://github.com/emilybache/Racing-Car-Katas/commit/389f96b83555405c9b82571dd16f632a60694b56
The open issue it addressed: https://github.com/emilybache/Racing-Car-Katas/issues/36