### PR TITLE
Config goggle test for Windows

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -4,6 +4,7 @@ project(Tennis-Refactoring)
 option(USE_GOOGLE_TEST "If to use google test" ON)
 
 if (USE_GOOGLE_TEST)
+    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
     include(FetchContent)
 
     FetchContent_Declare(


### PR DESCRIPTION
Adds the gtest_force_shared_crt setting making google test
follow the shared library settings in windows builds.