### PR TITLE
CSharp: Add xunit vs adapter for running tests

### DIFF
--- a/csharp/Tennis/Tennis.csproj
+++ b/csharp/Tennis/Tennis.csproj
@@ -9,6 +9,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This fixes issue #77 by adding the NuGet package: `xunit.runner.visualstudio`. Despite the name, this does not require visual studio to be installed or anything, it just allows tests to be run in Visual Studio, Visual Studio Code and `dotnet test`, amongst others. The xunit [Getting Started](https://xunit.net/docs/getting-started/netcore/cmdline) page has a good overview of the different packages required, the relevant quote below:

> The packages xunit.runner.visualstudio and Microsoft.NET.Test.Sdk are required for being able to run your test project inside Visual Studio as well as with dotnet test. 

