### PR TITLE
cpp: Update CMakeLists.txt to fix build error on macOS using clang version 14.0.0

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,49 +1,41 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.14)
 project(Tennis-Kata)
 
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 include(FetchContent)
+include(GoogleTest)
+
+set(CMAKE_CXX_STANDARD 14)
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
 FetchContent_Declare(
         googletest
-        GIT_REPOSITORY https://github.com/google/googletest.git
-        GIT_TAG        release-1.10.0
+        URL https://github.com/google/googletest/archive/6b63c98ac43efc992122f1da12aaf0a0e0658206.zip
         GIT_SHALLOW    1
 )
+FetchContent_MakeAvailable(googletest)
 
-FetchContent_GetProperties(googletest)
-if(NOT googletest_POPULATED)
-    FetchContent_Populate(googletest)
-    add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR})
-endif()
-
-include(GoogleTest)
 enable_testing()
 
 add_executable(tennis1_google_test
         tennis1.cc
         gtest_all.cpp)
-target_link_libraries(tennis1_google_test gtest gmock gtest_main)
-target_compile_features(tennis1_google_test PUBLIC cxx_std_11)
+target_link_libraries(tennis1_google_test GTest::gtest_main)
 gtest_discover_tests(tennis1_google_test)
 
 add_executable(tennis2_google_test
         tennis2.cc
         gtest_all.cpp)
-target_link_libraries(tennis2_google_test gtest gmock gtest_main)
-target_compile_features(tennis2_google_test PUBLIC cxx_std_11)
+target_link_libraries(tennis2_google_test GTest::gtest_main)
 gtest_discover_tests(tennis2_google_test)
 
 add_executable(tennis3_google_test
         tennis3.cc
         gtest_all.cpp)
-target_link_libraries(tennis3_google_test gtest gmock gtest_main)
-target_compile_features(tennis3_google_test PUBLIC cxx_std_11)
+target_link_libraries(tennis3_google_test GTest::gtest_main)
 gtest_discover_tests(tennis3_google_test)
 
 add_executable(tennis4_google_test
         tennis4.cc
         gtest_all.cpp)
-target_link_libraries(tennis4_google_test gtest gmock gtest_main)
-target_compile_features(tennis4_google_test PUBLIC cxx_std_11)
+target_link_libraries(tennis4_google_test GTest::gtest_main)
 gtest_discover_tests(tennis4_google_test)

--- a/cpp/Readme.md
+++ b/cpp/Readme.md
@@ -7,30 +7,53 @@ git clone) during the cmake-setup process.
 
 ## Using CMake and Visual Studio, under Windows
 
-Sample setup (in a Windows console, using Git), and considering
-you are already located in this folder:
+### Option 1: Generate Visual Studio solution manually
 
-```
-mkdir build
-cd build
-cmake .. -G "Visual Studio 14 2015 Win64"
-Tennis-Refactoring.sln
-```
+1. Download and install CMake from cmake.org
+2. Sample setup (in a Windows console, using Git), and considering
+   you are already located in this folder:
+   
+   ```
+   mkdir build
+   cd build
+   cmake .. -G "Visual Studio 17 2022"
+   ```
+3. Open Tennis-Kata.sln in Visual Studio 2022
+   Visual Studio should start with the projects in it.
+   You will have four executables, each one for a
+   specific version of initial source code (1, 2, 3 and 4).
+   Tests are already complete, code is ready to refactor!
 
-Visual Studio should start with the projects in it.
-You will have three different projects, each one for a
-specific version of initial source code (1, 2 and 3).
-Tests are already complete, code is ready to refactor!
+### Option 2: Open directly in Visual Sudio 2022
+
+1. Start Visual Studio 2022
+2. Select `Open a local folder`
+3. Select the folder containg this readme.
+4. Visual Studio 2022 will generate a project and you can run tests for variant 1, 2, 3 or 4.
+
+See https://learn.microsoft.com/en-us/cpp/build/cmake-projects-in-visual-studio?view=msvc-170 for more information.
 
 ## Using CMake and Mingw, under Windows
-
+1. Install MSYS2 according to https://www.msys2.org/#installation
+1. Install a compiler toolchain according to https://code.visualstudio.com/docs/cpp/config-mingw#_prerequisites
+```
+pacman -S --needed base-devel mingw-w64-x86_64-toolchain
+```
+2. Install CMake in MSYS2 according to https://www.msys2.org/docs/cmake/
+```
+pacman -S mingw-w64-x86_64-cmake
+```
+3. Build and run tests
 ```
 mkdir build
 cd build
-cmake .. -G "MSYS Makefiles"
+cmake .. -G "MinGW Makefiles"
 cmake --build .
 ctest
 ```
+## Using CMake and CLion, under Windows
+CLion support CMake and you can open the project according to https://www.jetbrains.com/help/clion/creating-new-project-from-scratch.html.
+
 ## Using cmake under Ubuntu GNU/Linux
 Make sure cmake is installed (available as a snap or in the
 repositories)
@@ -44,3 +67,19 @@ ctest
 If you want to use a specific makefile generator, you can 
 specify it with the -G flag, just as in windows.
 (cmake --help will give you a list of available generators.)
+
+## Using CLion, under macOS
+CLion support CMake and you can open the project according to https://www.jetbrains.com/help/clion/creating-new-project-from-scratch.html.
+
+## Using CMake, under macOS
+1. Install brew.sh
+2. Install cmake
+   `% brew install cmake`
+3. Build and run tests
+```
+mkdir build
+cd build
+cmake .. -G "Unix Makefiles"
+cmake --build .
+ctest
+```


### PR DESCRIPTION
**Background:**
I made a proposal of updating the CMakeLists.txt file since I get a build error on macOS.
```
/Users/jmossberg/git/sammancoaching/Tennis-Refactoring-Kata/cpp/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:891:3: error: definition of implicit copy constructor for 'EndsWithMatcher<std::wstring>' is deprecated because it has a user-declared copy assignment operator [-Werror,-Wdeprecated-copy]
  GTEST_DISALLOW_ASSIGN_(EndsWithMatcher);
  ^
```
I get the build error when using the following versions of `cmake` and `g++` on macOS.
```
 % cmake --version
cmake version 3.24.3

CMake suite maintained and supported by Kitware (kitware.com/cmake).
```
```
% g++ --version
Apple clang version 14.0.0 (clang-1400.0.29.202)
Target: arm64-apple-darwin22.1.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```
**Changes:**
* Update CMakeLists.txt based on instructions at https://google.github.io/googletest/quickstart-cmake.html.
* Probably the change that fixed the build error was to use a later version of Google Test. However I made some other changes according to the Google Test quickstart guide.
* Verified in CLion on macOS
* Verified using cmake installed via brew.sh on macOS
* Verified using Visual Studio 2022 on Windows 10
* Verified using MSYS2 on Windows 10
* Update Readme