### PR TITLE
remove hard-coding of "player1" and "player2" to make the Java code correct before starting refactoring

### DIFF
--- a/java/src/main/java/TennisGame1.java
+++ b/java/src/main/java/TennisGame1.java
@@ -12,7 +12,7 @@ public class TennisGame1 implements TennisGame {
     }
 
     public void wonPoint(String playerName) {
-        if (playerName == "player1")
+        if (playerName == player1Name)
             m_score1 += 1;
         else
             m_score2 += 1;
@@ -43,10 +43,10 @@ public class TennisGame1 implements TennisGame {
         else if (m_score1>=4 || m_score2>=4)
         {
             int minusResult = m_score1-m_score2;
-            if (minusResult==1) score ="Advantage player1";
-            else if (minusResult ==-1) score ="Advantage player2";
-            else if (minusResult>=2) score = "Win for player1";
-            else score ="Win for player2";
+            if (minusResult==1) score = "Advantage " + player1Name;
+            else if (minusResult ==-1) score = "Advantage " + player2Name;
+            else if (minusResult>=2) score = "Win for " + player1Name;
+            else score = "Win for " + player2Name;
         }
         else
         {

--- a/java/src/main/java/TennisGame2.java
+++ b/java/src/main/java/TennisGame2.java
@@ -81,21 +81,21 @@ public class TennisGame2 implements TennisGame
         
         if (P1point > P2point && P2point >= 3)
         {
-            score = "Advantage player1";
+            score = "Advantage " + player1Name;
         }
         
         if (P2point > P1point && P1point >= 3)
         {
-            score = "Advantage player2";
+            score = "Advantage " + player2Name;
         }
         
         if (P1point>=4 && P2point>=0 && (P1point-P2point)>=2)
         {
-            score = "Win for player1";
+            score = "Win for " + player1Name;
         }
         if (P2point>=4 && P1point>=0 && (P2point-P1point)>=2)
         {
-            score = "Win for player2";
+            score = "Win for " + player2Name;
         }
         return score;
     }
@@ -127,7 +127,7 @@ public class TennisGame2 implements TennisGame
     }
 
     public void wonPoint(String player) {
-        if (player == "player1")
+        if (player == player1Name)
             P1Score();
         else
             P2Score();

--- a/java/src/main/java/TennisGame3.java
+++ b/java/src/main/java/TennisGame3.java
@@ -26,7 +26,7 @@ public class TennisGame3 implements TennisGame {
     }
     
     public void wonPoint(String playerName) {
-        if (playerName == "player1")
+        if (playerName == p1N)
             this.p1 += 1;
         else
             this.p2 += 1;

--- a/java/src/test/java/TennisTest.java
+++ b/java/src/test/java/TennisTest.java
@@ -1,11 +1,15 @@
 import org.junit.jupiter.params.ParameterizedTest;
 
+import java.util.Random;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.params.provider.MethodSource;
 
 public class TennisTest {
+
+    private static final String PLAYER_1_NAME = "player1-" + aRandomString();
+    private static final String PLAYER_2_NAME = "player2-" + aRandomString();
 
     public static Stream<Object[]> getAllScores() {
         return Stream.of(new Object[][]{
@@ -21,32 +25,32 @@ public class TennisTest {
                 {0, 2, "Love-Thirty"},
                 {3, 0, "Forty-Love"},
                 {0, 3, "Love-Forty"},
-                {4, 0, "Win for player1"},
-                {0, 4, "Win for player2"},
+                {4, 0, "Win for " + PLAYER_1_NAME},
+                {0, 4, "Win for " + PLAYER_2_NAME},
 
                 {2, 1, "Thirty-Fifteen"},
                 {1, 2, "Fifteen-Thirty"},
                 {3, 1, "Forty-Fifteen"},
                 {1, 3, "Fifteen-Forty"},
-                {4, 1, "Win for player1"},
-                {1, 4, "Win for player2"},
+                {4, 1, "Win for " + PLAYER_1_NAME},
+                {1, 4, "Win for " + PLAYER_2_NAME},
 
                 {3, 2, "Forty-Thirty"},
                 {2, 3, "Thirty-Forty"},
-                {4, 2, "Win for player1"},
-                {2, 4, "Win for player2"},
+                {4, 2, "Win for " + PLAYER_1_NAME},
+                {2, 4, "Win for " + PLAYER_2_NAME},
 
-                {4, 3, "Advantage player1"},
-                {3, 4, "Advantage player2"},
-                {5, 4, "Advantage player1"},
-                {4, 5, "Advantage player2"},
-                {15, 14, "Advantage player1"},
-                {14, 15, "Advantage player2"},
+                {4, 3, "Advantage " + PLAYER_1_NAME},
+                {3, 4, "Advantage " + PLAYER_2_NAME},
+                {5, 4, "Advantage " + PLAYER_1_NAME},
+                {4, 5, "Advantage " + PLAYER_2_NAME},
+                {15, 14, "Advantage " + PLAYER_1_NAME},
+                {14, 15, "Advantage " + PLAYER_2_NAME},
 
-                {6, 4, "Win for player1"},
-                {4, 6, "Win for player2"},
-                {16, 14, "Win for player1"},
-                {14, 16, "Win for player2"},
+                {6, 4, "Win for " + PLAYER_1_NAME},
+                {4, 6, "Win for " + PLAYER_2_NAME},
+                {16, 14, "Win for " + PLAYER_1_NAME},
+                {14, 16, "Win for " + PLAYER_2_NAME},
         });
     }
 
@@ -54,9 +58,9 @@ public class TennisTest {
         int highestScore = Math.max(player1Points, player2Points);
         for (int i = 0; i < highestScore; i++) {
             if (i < player1Points)
-                game.wonPoint("player1");
+                game.wonPoint(PLAYER_1_NAME);
             if (i < player2Points)
-                game.wonPoint("player2");
+                game.wonPoint(PLAYER_2_NAME);
         }
         assertEquals(expectedScore, game.getScore());
     }
@@ -64,29 +68,32 @@ public class TennisTest {
     @ParameterizedTest
     @MethodSource("getAllScores")
     public void checkAllScoresTennisGame1(int player1Points, int player2Points, String expectedScore) {
-        TennisGame1 game = new TennisGame1("player1", "player2");
+        TennisGame1 game = new TennisGame1(PLAYER_1_NAME, PLAYER_2_NAME);
         checkAllScores(player1Points, player2Points, expectedScore, game);
     }
 
     @ParameterizedTest
     @MethodSource("getAllScores")
     public void checkAllScoresTennisGame2(int player1Points, int player2Points, String expectedScore) {
-        TennisGame2 game = new TennisGame2("player1", "player2");
+        TennisGame2 game = new TennisGame2(PLAYER_1_NAME, PLAYER_2_NAME);
         checkAllScores(player1Points, player2Points, expectedScore, game);
     }
 
     @ParameterizedTest
     @MethodSource("getAllScores")
     public void checkAllScoresTennisGame3(int player1Points, int player2Points, String expectedScore) {
-        TennisGame3 game = new TennisGame3("player1", "player2");
+        TennisGame3 game = new TennisGame3(PLAYER_1_NAME, PLAYER_2_NAME);
         checkAllScores(player1Points, player2Points, expectedScore, game);
     }
 
     @ParameterizedTest
     @MethodSource("getAllScores")
     public void checkAllScoresTennisGame4(int player1Points, int player2Points, String expectedScore) {
-        TennisGame game = new TennisGame4("player1", "player2");
+        TennisGame game = new TennisGame4(PLAYER_1_NAME, PLAYER_2_NAME);
         checkAllScores(player1Points, player2Points, expectedScore, game);
     }
 
+    private static String aRandomString() {
+        return String.valueOf(new Random().nextInt(0, 1000));
+    }
 }


### PR DESCRIPTION
This is for the Java code only.

Three of the TennisGame implementations use hardcoded Strings "player1" and "player2" to check which player is playing.
This means that those classes only give the correct results if the player names happen to be "player1" and "player2" - which they are in the tests but I believe it is not the intention that only those names should give the correct results.

This change is to make those implementations use the player names which the TennisGame was created with, so they work correctly with any player names.

The test has been updated to introduce randomness in the player names in order to show that the scoring works correctly regardless of the names. The randomness does not introduce any non-determinism.