### PR TITLE
remove hard-coding of "player1" and "player2" to make the Kotlin code correct before starting refactoring

### DIFF
--- a/kotlin/src/main/kotlin/TennisGame1.kt
+++ b/kotlin/src/main/kotlin/TennisGame1.kt
@@ -4,7 +4,7 @@ class TennisGame1(private val player1Name: String, private val player2Name: Stri
     private var m_score2: Int = 0
 
     override fun wonPoint(playerName: String) {
-        if (playerName === "player1")
+        if (playerName === player1Name)
             m_score1 += 1
         else
             m_score2 += 1
@@ -23,13 +23,13 @@ class TennisGame1(private val player1Name: String, private val player2Name: Stri
         } else if (m_score1 >= 4 || m_score2 >= 4) {
             val minusResult = m_score1 - m_score2
             if (minusResult == 1)
-                score = "Advantage player1"
+                score = "Advantage $player1Name"
             else if (minusResult == -1)
-                score = "Advantage player2"
+                score = "Advantage $player2Name"
             else if (minusResult >= 2)
-                score = "Win for player1"
+                score = "Win for $player1Name"
             else
-                score = "Win for player2"
+                score = "Win for $player2Name"
         } else {
             for (i in 1..2) {
                 if (i == 1)

--- a/kotlin/src/main/kotlin/TennisGame2.kt
+++ b/kotlin/src/main/kotlin/TennisGame2.kt
@@ -66,18 +66,18 @@ class TennisGame2(private val player1Name: String, private val player2Name: Stri
         }
 
         if (P1point > P2point && P2point >= 3) {
-            score = "Advantage player1"
+            score = "Advantage $player1Name"
         }
 
         if (P2point > P1point && P1point >= 3) {
-            score = "Advantage player2"
+            score = "Advantage $player2Name"
         }
 
         if (P1point >= 4 && P2point >= 0 && P1point - P2point >= 2) {
-            score = "Win for player1"
+            score = "Win for $player1Name"
         }
         if (P2point >= 4 && P1point >= 0 && P2point - P1point >= 2) {
-            score = "Win for player2"
+            score = "Win for $player2Name"
         }
         return score
     }
@@ -107,7 +107,7 @@ class TennisGame2(private val player1Name: String, private val player2Name: Stri
     }
 
     override fun wonPoint(player: String) {
-        if (player === "player1")
+        if (player === player1Name)
             P1Score()
         else
             P2Score()

--- a/kotlin/src/main/kotlin/TennisGame3.kt
+++ b/kotlin/src/main/kotlin/TennisGame3.kt
@@ -18,7 +18,7 @@ class TennisGame3(private val p1N: String, private val p2N: String) : TennisGame
     }
 
     override fun wonPoint(playerName: String) {
-        if (playerName === "player1")
+        if (playerName === p1N)
             this.p1 += 1
         else
             this.p2 += 1

--- a/kotlin/src/test/kotlin/TennisTest.kt
+++ b/kotlin/src/test/kotlin/TennisTest.kt
@@ -2,34 +2,35 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
+import kotlin.random.Random
 
 class TennisTest {
 
     @ParameterizedTest
     @MethodSource("allScores")
     fun checkAllScoresTennisGame1(player1Score: Int, player2Score: Int, expectedScore: String) {
-        val game = TennisGame1("player1", "player2")
+        val game = TennisGame1(player1Name, player2Name)
         checkAllScores(game, player1Score, player2Score, expectedScore)
     }
 
     @ParameterizedTest
     @MethodSource("allScores")
     fun checkAllScoresTennisGame2(player1Score: Int, player2Score: Int, expectedScore: String) {
-        val game = TennisGame2("player1", "player2")
+        val game = TennisGame2(player1Name, player2Name)
         checkAllScores(game, player1Score, player2Score, expectedScore)
     }
 
     @ParameterizedTest
     @MethodSource("allScores")
     fun checkAllScoresTennisGame3(player1Score: Int, player2Score: Int, expectedScore: String) {
-        val game = TennisGame3("player1", "player2")
+        val game = TennisGame3(player1Name, player2Name)
         checkAllScores(game, player1Score, player2Score, expectedScore)
     }
 
     @ParameterizedTest
     @MethodSource("allScores")
     fun checkAllScoresTennisGame4(player1Score: Int, player2Score: Int, expectedScore: String) {
-        val game = TennisGame4("player1", "player2")
+        val game = TennisGame4(player1Name, player2Name)
         checkAllScores(game, player1Score, player2Score, expectedScore)
     }
 
@@ -37,14 +38,17 @@ class TennisTest {
         val highestScore = Math.max(player1Score, player2Score)
         for (i in 0 until highestScore) {
             if (i < player1Score)
-                game.wonPoint("player1")
+                game.wonPoint(player1Name)
             if (i < player2Score)
-                game.wonPoint("player2")
+                game.wonPoint(player2Name)
         }
         assertEquals(expectedScore, game.getScore())
     }
 
     companion object {
+        private val player1Name = "player1-" + aRandomString()
+        private val player2Name = "player2-" + aRandomString()
+
         @JvmStatic
         fun allScores(): List<Arguments> =
             listOf(
@@ -59,28 +63,30 @@ class TennisTest {
                 Arguments.of(0, 2, "Love-Thirty"),
                 Arguments.of(3, 0, "Forty-Love"),
                 Arguments.of(0, 3, "Love-Forty"),
-                Arguments.of(4, 0, "Win for player1"),
-                Arguments.of(0, 4, "Win for player2"),
+                Arguments.of(4, 0, "Win for $player1Name"),
+                Arguments.of(0, 4, "Win for $player2Name"),
                 Arguments.of(2, 1, "Thirty-Fifteen"),
                 Arguments.of(1, 2, "Fifteen-Thirty"),
                 Arguments.of(3, 1, "Forty-Fifteen"),
                 Arguments.of(1, 3, "Fifteen-Forty"),
-                Arguments.of(4, 1, "Win for player1"),
-                Arguments.of(1, 4, "Win for player2"),
+                Arguments.of(4, 1, "Win for $player1Name"),
+                Arguments.of(1, 4, "Win for $player2Name"),
                 Arguments.of(3, 2, "Forty-Thirty"),
                 Arguments.of(2, 3, "Thirty-Forty"),
-                Arguments.of(4, 2, "Win for player1"),
-                Arguments.of(2, 4, "Win for player2"),
-                Arguments.of(4, 3, "Advantage player1"),
-                Arguments.of(3, 4, "Advantage player2"),
-                Arguments.of(5, 4, "Advantage player1"),
-                Arguments.of(4, 5, "Advantage player2"),
-                Arguments.of(15, 14, "Advantage player1"),
-                Arguments.of(14, 15, "Advantage player2"),
-                Arguments.of(6, 4, "Win for player1"),
-                Arguments.of(4, 6, "Win for player2"),
-                Arguments.of(16, 14, "Win for player1"),
-                Arguments.of(14, 16, "Win for player2")
+                Arguments.of(4, 2, "Win for $player1Name"),
+                Arguments.of(2, 4, "Win for $player2Name"),
+                Arguments.of(4, 3, "Advantage $player1Name"),
+                Arguments.of(3, 4, "Advantage $player2Name"),
+                Arguments.of(5, 4, "Advantage $player1Name"),
+                Arguments.of(4, 5, "Advantage $player2Name"),
+                Arguments.of(15, 14, "Advantage $player1Name"),
+                Arguments.of(14, 15, "Advantage $player2Name"),
+                Arguments.of(6, 4, "Win for $player1Name"),
+                Arguments.of(4, 6, "Win for $player2Name"),
+                Arguments.of(16, 14, "Win for $player1Name"),
+                Arguments.of(14, 16, "Win for $player2Name")
             )
+
+        private fun aRandomString() = Random.nextInt(0, 1000).toString()
     }
 }


### PR DESCRIPTION
remove hard-coding of "player1" and "player2" to make the Kotlin code correct before starting refactoring

This is for the Kotlin code only.

Three of the TennisGame implementations use hardcoded Strings "player1" and "player2" to check which player is playing.
This means that those classes only give the correct results if the player names happen to be "player1" and "player2" - which they are in the tests but I believe it is not the intention that only those names should give the correct results.

This change is to make those implementations use the player names which the TennisGame was created with, so they work correctly with any player names.

The test has been updated to introduce randomness in the player names in order to show that the scoring works correctly regardless of the names. The randomness does not introduce any non-determinism.