### PR TITLE
remove hard-coding of "player1" and "player2" to make the Scala code correct before starting refactoring

### DIFF
--- a/scala/src/main/scala/tennis/TennisGame1.scala
+++ b/scala/src/main/scala/tennis/TennisGame1.scala
@@ -5,7 +5,7 @@ class TennisGame1 (val player1Name : String, val player2Name : String) extends T
   var m_score2: Int = 0
 
   def wonPoint(playerName : String) {
-          if (playerName == "player1")
+          if (playerName == player1Name)
               m_score1 += 1
           else
               m_score2 += 1
@@ -27,10 +27,10 @@ class TennisGame1 (val player1Name : String, val player2Name : String) extends T
       else if (m_score1>=4 || m_score2>=4)
       {
           val minusResult = m_score1-m_score2
-          if (minusResult==1) score ="Advantage player1"
-          else if (minusResult == -1) score ="Advantage player2"
-          else if (minusResult>=2) score = "Win for player1"
-          else score ="Win for player2"
+          if (minusResult==1) score =s"Advantage $player1Name"
+          else if (minusResult == -1) score =s"Advantage $player2Name"
+          else if (minusResult>=2) score = s"Win for $player1Name"
+          else score =s"Win for $player2Name"
       }
       else
       {

--- a/scala/src/main/scala/tennis/TennisGame2.scala
+++ b/scala/src/main/scala/tennis/TennisGame2.scala
@@ -75,21 +75,21 @@ class TennisGame2 (val player1Name : String, val player2Name : String) extends T
 
         if (P1point > P2point && P2point >= 3)
         {
-            score = "Advantage player1"
+            score = s"Advantage $player1Name"
         }
 
         if (P2point > P1point && P1point >= 3)
         {
-            score = "Advantage player2"
+            score = s"Advantage $player2Name"
         }
 
         if (P1point>=4 && P2point>=0 && (P1point-P2point)>=2)
         {
-            score = "Win for player1"
+            score = s"Win for $player1Name"
         }
         if (P2point>=4 && P1point>=0 && (P2point-P1point)>=2)
         {
-            score = "Win for player2"
+            score = s"Win for $player2Name"
         }
         return score
     }
@@ -117,7 +117,7 @@ class TennisGame2 (val player1Name : String, val player2Name : String) extends T
     }
 
     def wonPoint(player : String) {
-        if (player == "player1")
+        if (player == player1Name)
             P1Score()
         else
             P2Score()

--- a/scala/src/main/scala/tennis/TennisGame3.scala
+++ b/scala/src/main/scala/tennis/TennisGame3.scala
@@ -22,7 +22,7 @@ class TennisGame3 (val p1N : String, val p2N : String) extends TennisGame {
   }
 
   def wonPoint(playerName : String) {
-    if (playerName == "player1")
+    if (playerName == p1N)
       this.p1 += 1
     else
       this.p2 += 1

--- a/scala/src/test/scala/tennis/TennisTest.scala
+++ b/scala/src/test/scala/tennis/TennisTest.scala
@@ -1,12 +1,14 @@
 package tennis
 
 import org.junit.Assert._
-
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import org.junit.runners.Parameterized.Parameters
+import tennis.TennisTest.{player1Name, player2Name}
+
 import java.util
+import scala.util.Random
 
 @RunWith(classOf[Parameterized])
 class TennisTest(params: TennisTestCase) {
@@ -15,35 +17,38 @@ class TennisTest(params: TennisTestCase) {
     val highestScore = Math.max(params.player1Score, params.player2Score)
       for (i <- 0 until highestScore by 1) {
           if (i < params.player1Score)
-              game.wonPoint("player1")
+              game.wonPoint(player1Name)
           if (i < params.player2Score)
-              game.wonPoint("player2")
+              game.wonPoint(player2Name)
       }
       assertEquals(params.expectedScore, game.calculateScore())
   }
 
   @Test
   def checkGame1() {
-      val game = new TennisGame1("player1", "player2")
+      val game = new TennisGame1(player1Name, player2Name)
       checkScores(game)
   }
 
   @Test
   def checkGame2() {
-      val game = new TennisGame2("player1", "player2")
+      val game = new TennisGame2(player1Name, player2Name)
       checkScores(game)
   }
 
 
   @Test
   def checkGame3() {
-      val game = new TennisGame3("player1", "player2")
+      val game = new TennisGame3(player1Name, player2Name)
       checkScores(game)
   }
 
 }
 
 object TennisTest {
+  val player1Name = "player1-" + aRandomString
+  val player2Name = "player2-" + aRandomString
+  
   @Parameters(name = "{0}")
   def getAllScores() : java.util.Collection[Array[TennisTestCase]] = {
       var list = new util.ArrayList[Array[TennisTestCase]]();
@@ -61,34 +66,38 @@ object TennisTest {
         new TennisTestCase( 0, 2, "Love-Thirty"),
         new TennisTestCase( 3, 0, "Forty-Love"),
         new TennisTestCase( 0, 3, "Love-Forty"),
-        new TennisTestCase( 4, 0, "Win for player1"),
-        new TennisTestCase( 0, 4, "Win for player2"),
+        new TennisTestCase( 4, 0, s"Win for $player1Name"),
+        new TennisTestCase( 0, 4, s"Win for $player2Name"),
 
         new TennisTestCase( 2, 1, "Thirty-Fifteen"),
         new TennisTestCase( 1, 2, "Fifteen-Thirty"),
         new TennisTestCase( 3, 1, "Forty-Fifteen"),
         new TennisTestCase( 1, 3, "Fifteen-Forty"),
-        new TennisTestCase( 4, 1, "Win for player1"),
-        new TennisTestCase( 1, 4, "Win for player2"),
+        new TennisTestCase( 4, 1, s"Win for $player1Name"),
+        new TennisTestCase( 1, 4, s"Win for $player2Name"),
 
         new TennisTestCase( 3, 2, "Forty-Thirty"),
         new TennisTestCase( 2, 3, "Thirty-Forty"),
-        new TennisTestCase( 4, 2, "Win for player1"),
-        new TennisTestCase( 2, 4, "Win for player2"),
+        new TennisTestCase( 4, 2, s"Win for $player1Name"),
+        new TennisTestCase( 2, 4, s"Win for $player2Name"),
 
-        new TennisTestCase( 4, 3, "Advantage player1"),
-        new TennisTestCase( 3, 4, "Advantage player2"),
-        new TennisTestCase( 5, 4, "Advantage player1"),
-        new TennisTestCase( 4, 5, "Advantage player2"),
-        new TennisTestCase( 15, 14, "Advantage player1"),
-        new TennisTestCase( 14, 15, "Advantage player2"),
+        new TennisTestCase( 4, 3, s"Advantage $player1Name"),
+        new TennisTestCase( 3, 4, s"Advantage $player2Name"),
+        new TennisTestCase( 5, 4, s"Advantage $player1Name"),
+        new TennisTestCase( 4, 5, s"Advantage $player2Name"),
+        new TennisTestCase( 15, 14, s"Advantage $player1Name"),
+        new TennisTestCase( 14, 15, s"Advantage $player2Name"),
 
-        new TennisTestCase( 6, 4, "Win for player1"),
-        new TennisTestCase( 4, 6, "Win for player2"),
-        new TennisTestCase( 16, 14, "Win for player1"),
-        new TennisTestCase( 14, 16, "Win for player2")
+        new TennisTestCase( 6, 4, s"Win for $player1Name"),
+        new TennisTestCase( 4, 6, s"Win for $player2Name"),
+        new TennisTestCase( 16, 14, s"Win for $player1Name"),
+        new TennisTestCase( 14, 16, s"Win for $player2Name")
      )
      args.foreach(n => list.add(Array(n)))
      return list
+  }
+
+  private def aRandomString = {
+    Random.nextInt(1000).toString
   }
 }


### PR DESCRIPTION
This is for the Scala code only.

The three TennisGame implementations use hardcoded Strings "player1" and "player2" to check which player is playing.
This means that those classes only give the correct results if the player names happen to be "player1" and "player2" - which they are in the tests but I believe it is not the intention that only those names should give the correct results.

This change is to make those implementations use the player names which the TennisGame was created with, so they work correctly with any player names.

The test has been updated to introduce randomness in the player names in order to show that the scoring works correctly regardless of the names. The randomness does not introduce any non-determinism.