### PR TITLE
Fix ts2304/2307 errors in typescript and typescript-jest version

### DIFF
--- a/typescript-jest/tsconfig.json
+++ b/typescript-jest/tsconfig.json
@@ -23,7 +23,7 @@
   },
   "include": [
     "./src/**.ts",
-    "./test/*.spec.ts"
+    "./tests/*.spec.ts"
   ],
   "exclude": [
     "node_modules",

--- a/typescript/tsconfig.json
+++ b/typescript/tsconfig.json
@@ -25,7 +25,7 @@
     ]
   },
   "include": [
-    "./test/*.ts",
+    "./tests/*.ts",
     "./src/**.ts"
   ],
   "exclude": [


### PR DESCRIPTION
![image](https://github.com/emilybache/Tennis-Refactoring-Kata/assets/54790378/4208e821-2290-4c22-a83d-1cd48265f4d1)

While trying to practice this kata with TS, I ran into a TS2307 and TS2304 error in the project's spec file, even though I had done `npm install`.

After a little digging, I found a small typo in the `include` property of `tsconfig`, which I fixed and the error went away.

+) I've been having a lot of fun practicing these katas lately, starting with Gilded Rose. Thank you for sharing! 😃 