### PR TITLE
Use more recent versions in Kotlin version

### DIFF
--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 plugins {
     kotlin("jvm") version "2.0.0"
     application

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -13,7 +13,7 @@ repositories {
 }
 
 dependencies {
-    testImplementation("org.junit.jupiter:junit-jupiter:5.7.0")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.10.2")
 }
 
 tasks.test {

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -18,17 +18,8 @@ tasks.test {
     useJUnitPlatform()
 }
 
-val javaVersion = JavaLanguageVersion.of(21)
-
 kotlin {
     jvmToolchain {
-        languageVersion.set(javaVersion)
+        languageVersion.set(JavaLanguageVersion.of(21))
     }
 }
-
-java {
-    toolchain {
-        languageVersion.set(javaVersion)
-    }
-}
-

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -20,6 +20,17 @@ tasks.test {
     useJUnitPlatform()
 }
 
-tasks.withType<KotlinCompile>() {
-    kotlinOptions.jvmTarget = "1.8"
+val javaVersion = JavaVersion.VERSION_1_8
+
+kotlin {
+    jvmToolchain {
+        languageVersion.set(JavaLanguageVersion.of(javaVersion.majorVersion))
+    }
 }
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(javaVersion.majorVersion))
+    }
+}
+

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "1.5.10"
+    kotlin("jvm") version "2.0.0"
     application
 }
 

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -20,17 +20,17 @@ tasks.test {
     useJUnitPlatform()
 }
 
-val javaVersion = JavaVersion.VERSION_1_8
+val javaVersion = JavaLanguageVersion.of(21)
 
 kotlin {
     jvmToolchain {
-        languageVersion.set(JavaLanguageVersion.of(javaVersion.majorVersion))
+        languageVersion.set(javaVersion)
     }
 }
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(javaVersion.majorVersion))
+        languageVersion.set(javaVersion)
     }
 }
 

--- a/kotlin/gradle/wrapper/gradle-wrapper.properties
+++ b/kotlin/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR upgrades versions of Kotlin, Gradle, JUnit and the Java version used for compiling to the most recent versions (except for Java where I've used 21 since that's an LTS release).