### PR TITLE
Specify javac's --release option instead of --source and --target in … POM to get rid of a warning

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -9,8 +9,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>22</maven.compiler.source>
-        <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
+        <maven.compiler.release>22</maven.compiler.release>
 
         <junit.jupiter.version>5.13.4</junit.jupiter.version>
     </properties>


### PR DESCRIPTION
As recommended [here](https://maven.apache.org/plugins/maven-compiler-plugin/examples/set-compiler-source-and-target.html).